### PR TITLE
write out cenc-sbtl atoms every fragment

### DIFF
--- a/libavformat/movenc.c
+++ b/libavformat/movenc.c
@@ -2568,7 +2568,7 @@ static int mov_write_stbl_tag(AVFormatContext *s, AVIOContext *pb, MOVMuxContext
     mov_write_stsc_tag(pb, track);
     mov_write_stsz_tag(pb, track);
     mov_write_stco_tag(pb, track);
-    if (track->cenc.aes_ctr) {
+    if (track->cenc.aes_ctr && !(mov->flags & FF_MOV_FLAG_FRAGMENT)) {
         ff_mov_cenc_write_stbl_atoms(&track->cenc, pb);
     }
     if (track->par->codec_id == AV_CODEC_ID_OPUS || track->par->codec_id == AV_CODEC_ID_AAC) {
@@ -4549,6 +4549,13 @@ static int mov_write_traf_tag(AVIOContext *pb, MOVMuxContext *mov,
         }
     }
     mov_write_trun_tag(pb, mov, track, moof_size, start, track->entry);
+    if (track->cenc.aes_ctr) {
+        ff_mov_cenc_write_stbl_atoms(&track->cenc, pb);
+        if (moof_size > 0)
+        {
+            ff_mov_cenc_reset_auxiliary_info(&track->cenc);
+        }
+    }
     if (mov->mode == MODE_ISM) {
         mov_write_tfxd_tag(pb, track);
 

--- a/libavformat/movenccenc.c
+++ b/libavformat/movenccenc.c
@@ -24,6 +24,12 @@
 #include "movenc.h"
 #include "avc.h"
 
+void ff_mov_cenc_reset_auxiliary_info(MOVMuxCencContext* ctx)
+{
+    ctx->auxiliary_info_size = 0;
+    ctx->auxiliary_info_entries = 0;
+}
+
 static int auxiliary_info_alloc_size(MOVMuxCencContext* ctx, int size)
 {
     size_t new_alloc_size;

--- a/libavformat/movenccenc.h
+++ b/libavformat/movenccenc.h
@@ -79,6 +79,11 @@ int ff_mov_cenc_avc_write_nal_units(AVFormatContext *s, MOVMuxCencContext* ctx, 
 void ff_mov_cenc_write_stbl_atoms(MOVMuxCencContext* ctx, AVIOContext *pb);
 
 /**
+ * Reset the Auxiliary info sizes
+ */
+void ff_mov_cenc_reset_auxiliary_info(MOVMuxCencContext* ctx);
+
+/**
  * Write the sinf atom, contained inside stsd
  */
 int ff_mov_cenc_write_sinf_tag(struct MOVTrack* track, AVIOContext *pb, uint8_t* kid);


### PR DESCRIPTION
Unsure of how where we actually want this commit to sit? I think the latest release for ffmpeg is 4.2.3 @svensht2 do you want to just go off of that tag?

Essentially what this does is write out the cenc stbl atoms (saiz, saio, senc) along with the associated subsample auxiliary information for each fragment.   Beforehand, this information would only be written into the header before this information would actually be determined.